### PR TITLE
Fix: add missing #include <cstdint> for GCC 13+ compatibility

### DIFF
--- a/src/backend/aliases.h
+++ b/src/backend/aliases.h
@@ -4,6 +4,7 @@
 #ifndef ALIASES_H
 #define ALIASES_H
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/backend/asm_types.cpp
+++ b/src/backend/asm_types.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "asm_types.h"
 #include "logger.h"
 #include "utils.h"

--- a/src/backend/asm_types.h
+++ b/src/backend/asm_types.h
@@ -4,6 +4,7 @@
 #ifndef ASM_TYPES_H
 #define ASM_TYPES_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <iostream>

--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <algorithm>
 #include <cassert>
 #include <cctype>

--- a/src/backend/assembler.h
+++ b/src/backend/assembler.h
@@ -4,6 +4,7 @@
 #ifndef ASSEMBLER_H
 #define ASSEMBLER_H
 
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <vector>

--- a/src/backend/converter.cpp
+++ b/src/backend/converter.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <algorithm>
 #include <bitset>
 #include <fstream>

--- a/src/backend/converter.h
+++ b/src/backend/converter.h
@@ -4,6 +4,7 @@
 #ifndef CONVERTER_H
 #define CONVERTER_H
 
+#include <cstdint>
 #include <memory>
 
 #include "logger.h"

--- a/src/backend/decoder.cpp
+++ b/src/backend/decoder.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "decoder.h"
 
 using namespace lc3::core::sim;

--- a/src/backend/decoder.h
+++ b/src/backend/decoder.h
@@ -4,6 +4,7 @@
 #ifndef DECODER_H
 #define DECODER_H
 
+#include <cstdint>
 #include "isa_abstract.h"
 #include "utils.h"
 

--- a/src/backend/device.cpp
+++ b/src/backend/device.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "device.h"
 
 using namespace lc3::core;

--- a/src/backend/device.h
+++ b/src/backend/device.h
@@ -4,6 +4,7 @@
 #ifndef DEVICE_H
 #define DEVICE_H
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <queue>

--- a/src/backend/encoder.cpp
+++ b/src/backend/encoder.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <cassert>

--- a/src/backend/encoder.h
+++ b/src/backend/encoder.h
@@ -4,6 +4,7 @@
 #ifndef INSTRUCTION_ENCODER_H
 #define INSTRUCTION_ENCODER_H
 
+#include <cstdint>
 #include <memory>
 
 #include "isa.h"

--- a/src/backend/event.cpp
+++ b/src/backend/event.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "event.h"
 #include "uop.h"
 #include "state.h"

--- a/src/backend/event.h
+++ b/src/backend/event.h
@@ -4,6 +4,7 @@
 #ifndef EVENT_H
 #define EVENT_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/backend/interface.cpp
+++ b/src/backend/interface.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <cassert>
 #include <chrono>
 #include <fstream>

--- a/src/backend/interface.h
+++ b/src/backend/interface.h
@@ -12,6 +12,7 @@
     #endif
 #endif
 
+#include <cstdint>
 #include <functional>
 #include <utility>
 

--- a/src/backend/intex.cpp
+++ b/src/backend/intex.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "intex.h"
 
 uint8_t lc3::core::getExceptionVector(ExceptionType type)

--- a/src/backend/isa_abstract.cpp
+++ b/src/backend/isa_abstract.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <sstream>
 
 #include "logger.h"

--- a/src/backend/isa_abstract.h
+++ b/src/backend/isa_abstract.h
@@ -4,6 +4,7 @@
 #ifndef ISA_ABSTRACT_H
 #define ISA_ABSTRACT_H
 
+#include <cstdint>
 #include <string>
 
 #include "aliases.h"

--- a/src/backend/isa_impl.cpp
+++ b/src/backend/isa_impl.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "isa.h"
 
 using namespace lc3::core;

--- a/src/backend/logger.h
+++ b/src/backend/logger.h
@@ -4,6 +4,7 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
+#include <cstdint>
 #include <vector>
 
 #include "asm_types.h"

--- a/src/backend/mem.cpp
+++ b/src/backend/mem.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <cstring>
 
 #include "mem.h"

--- a/src/backend/mem.h
+++ b/src/backend/mem.h
@@ -4,6 +4,7 @@
 #ifndef MEM_NEW_H
 #define MEM_NEW_H
 
+#include <cstdint>
 #include <string>
 #include <iostream>
 

--- a/src/backend/simulator.cpp
+++ b/src/backend/simulator.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "simulator.h"
 
 #include <algorithm>

--- a/src/backend/state.cpp
+++ b/src/backend/state.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "device_regs.h"
 #include "device.h"
 #include "state.h"

--- a/src/backend/state.h
+++ b/src/backend/state.h
@@ -4,6 +4,7 @@
 #ifndef STATE_H
 #define STATE_H
 
+#include <cstdint>
 #include <queue>
 #include <stack>
 #include <string>

--- a/src/backend/tokenizer.cpp
+++ b/src/backend/tokenizer.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <stdexcept>
 
 #include "tokenizer.h"

--- a/src/backend/uop.cpp
+++ b/src/backend/uop.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "decoder.h"
 #include "isa.h"
 #include "state.h"

--- a/src/backend/uop.h
+++ b/src/backend/uop.h
@@ -4,6 +4,7 @@
 #ifndef UOP_H
 #define UOP_H
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 

--- a/src/cli/asm_main.cpp
+++ b/src/cli/asm_main.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <string>
 
 #define API_VER 2

--- a/src/cli/sim_main.cpp
+++ b/src/cli/sim_main.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <algorithm>
 #ifdef _ENABLE_DEBUG
     #include <chrono>

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <cstring>
 
 #include "common.h"

--- a/src/gui/local_modules/lc3interface/wrapper.cpp
+++ b/src/gui/local_modules/lc3interface/wrapper.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <nan.h>
 
 #ifndef DEFAULT_PRINT_LEVEL

--- a/src/test/framework1.cpp
+++ b/src/test/framework1.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <memory>
 
 #include "common.h"

--- a/src/test/framework2.cpp
+++ b/src/test/framework2.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <memory>
 #include <math.h>
 

--- a/src/test/framework_common.cpp
+++ b/src/test/framework_common.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include "framework_common.h"
 
 bool endsWith(std::string const & search, std::string const & suffix)

--- a/src/test/tests/samples/binsearch.cpp
+++ b/src/test/tests/samples/binsearch.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #define API_VER 2
+#include <cstdint>
 #include "framework.h"
 
 static constexpr uint64_t InstLimit = 5000;

--- a/src/test/tests/samples/intersection.cpp
+++ b/src/test/tests/samples/intersection.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <algorithm>
 #include <iomanip>
 #include <set>

--- a/src/test/tests/samples/nim.cpp
+++ b/src/test/tests/samples/nim.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <cmath>
 #include <array>
 #include <vector>

--- a/src/test/tests/samples/polyroot.cpp
+++ b/src/test/tests/samples/polyroot.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #define API_VER 2
+#include <cstdint>
 #include "framework.h"
 
 uint32_t sub_count;

--- a/src/test/tests/samples/pow2.cpp
+++ b/src/test/tests/samples/pow2.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #define API_VER 2
+#include <cstdint>
 #include "framework.h"
 
 void verify(Tester & tester, lc3::sim & sim, bool success, uint16_t expected, double points)

--- a/src/test/tests/samples/rotate.cpp
+++ b/src/test/tests/samples/rotate.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #define API_VER 2
+#include <cstdint>
 #include "framework.h"
 
 static constexpr uint64_t InstLimit = 1000;

--- a/src/test/tests/samples/shift.cpp
+++ b/src/test/tests/samples/shift.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #define API_VER 2
+#include <cstdint>
 #include "framework.h"
 
 static constexpr uint64_t InstLimit = 1000;

--- a/src/test/tests/samples/sort.cpp
+++ b/src/test/tests/samples/sort.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
+#include <cstdint>
 #include <algorithm>
 #include <iomanip>
 #include <sstream>

--- a/src/test/tests/samples/tutorial_grader.cpp
+++ b/src/test/tests/samples/tutorial_grader.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #define API_VER 2
+#include <cstdint>
 #include "framework.h"
 
 void ZeroTest(lc3::sim & sim, Tester & tester, double total_points)


### PR DESCRIPTION
## Summary
- GCC 13+ no longer implicitly includes `<cstdint>` through other standard headers
- This causes compilation failures for all code using `uint8_t`, `uint16_t`, `uint32_t`, etc.
- Added explicit `#include <cstdint>` to all 46 source files that use fixed-width integer types

## Reproducing the issue
Build with GCC 13.x:
```
mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Release ..
make assembler
```
Fails with:
```
error: 'uint32_t' was not declared in this scope
note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```

## Test plan
- [x] Verified `make assembler` compiles successfully after the fix